### PR TITLE
chore: Upgraded keycloak version and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The goal of this [SPI (Service Provider Interface)](https://www.keycloak.org/doc
 
 Useful to provide SSO (Single Sign On) capabilities for legacy web application to a new web application being authenticated by Keycloak.
 
-__Important__ to note is that this SPI expects the legacy web application to be able to access a valid JWT. This might occur if you need to introduce new features in legacy web applications.
+__Important__ to note is that this SPI expects the legacy web application to be able to access a valid JWT. This might occur if you need to introduce new features in legacy web applications. Also the user must have email address assigned to them.
 
 ## Usage
 
@@ -20,7 +20,7 @@ var targetClientForNewSession = "application";
 var jwt = "eyJhbGciOiJSUzI1NiIs.....";
 // invocation
 var xmlHttp = new XMLHttpRequest();
-xmlHttp.open("GET", `${providerUrl}/auth/realms/${realm}/browser-session/init?publicClient=${targetClientForNewSession}`, false);
+xmlHttp.open("POST", `${providerUrl}/realms/${realm}/browser-session/init?publicClient=${targetClientForNewSession}`, false);
 xmlHttp.withCredentials = true;
 xmlHttp.setRequestHeader("Authorization", "Bearer " + jwt);
 xmlHttp.send(null);
@@ -35,12 +35,12 @@ It contains of one single API request:
 
 | HTTP Method | Path                                                                               | Request Header                              | Description                                                                                                                                                                                                        |
 |-------------|------------------------------------------------------------------------------------|---------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| GET         | `baseUrl`/auth/realms/`realm`/browser-session/init?publicClient=`targetClientName` | Ensure `Authorization: Bearer` with the JWT | `baseUrl`: URL to Keycloak e.g. <https://your.keycloak.example.org> <br> `realm`: realm to be used e.g. master <br> `targetClientName`: public client (defined in Keycloak) for which to start the browser session |
+| POST         | `baseUrl`/realms/`realm`/browser-session/init?publicClient=`targetClientName` | Ensure `Authorization: Bearer` with the JWT | `baseUrl`: URL to Keycloak e.g. <https://your.keycloak.example.org> <br> `realm`: realm to be used e.g. master <br> `targetClientName`: public client (defined in Keycloak) for which to start the browser session |
 
 ## Deployment
 
 1. Build with `mvn clean package`
-2. Copy resulting artifact `keycloak-spi-browser-session-api-1.0.jar` to the `deployments` folder of Keycloak
+2. Copy resulting artifact `keycloak-spi-browser-session-api-1.1.jar` to the `deployments` folder of Keycloak
 
 ## Configuration
 
@@ -67,7 +67,7 @@ The goal is to initiate a browser session from `start-app` only having a valid J
 
 Please configure Keycloak as follows:
 
-* login to Keycloak via <http://localhost/> (`user` / `bitnami`)
+* login to Keycloak via <http://localhost/> (`admin`)
 * create two clients
   * `dest-app` with access type `public` and Web Origin `http://localhost:5082` and/or `*`
   * `private` with access type `confidential`
@@ -77,7 +77,7 @@ Please configure Keycloak as follows:
 Build and deploy it
 
 ```sh
-mvn clean package && docker cp target/keycloak-spi-browser-session-api-1.0.jar keycloak-spi-browser-session-api-keycloak-1:/opt/bitnami/keycloak/standalone/deployments/keycloak-spi-browser-session-api-1.0.jar
+docker compose up
 ```
 
 Run the test by generating a new access token and placing it into the `demo/start-app/index.html`. This is only for demo purposes.
@@ -88,7 +88,7 @@ CLIENT_ID=private
 CLIENT_SECRET=8b3576db-6492-4238-aa60-d7c71a9663f7
 API_USER=testuser
 API_PASSWORD='Test123!'
-ACCESS_TOKEN=$(curl -s -d "client_id=$CLIENT_ID" -d "client_secret=$CLIENT_SECRET" --data-urlencode "username=$API_USER" --data-urlencode "password=$API_PASSWORD" -d 'grant_type=password' 'http://localhost:5080/auth/realms/master/protocol/openid-connect/token' | jq -r '.access_token')
+ACCESS_TOKEN=$(curl -s -d "client_id=$CLIENT_ID" -d "client_secret=$CLIENT_SECRET" --data-urlencode "username=$API_USER" --data-urlencode "password=$API_PASSWORD" -d 'grant_type=password' 'http://localhost:5080/realms/master/protocol/openid-connect/token' | jq -r '.access_token')
 sed -i -E 's#var jwt = ".*$#var jwt = "'"$ACCESS_TOKEN"'";#' demo/start-app/index.html
 ```
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,20 @@
+FROM maven:3-openjdk-17 AS build
+
+RUN useradd -m -U keycloak
+
+WORKDIR /app
+
+COPY . .
+
+RUN mvn clean package
+
+FROM quay.io/keycloak/keycloak:latest AS kcbuild
+
+COPY --from=build /app/target/*.jar /opt/keycloak/providers/
+
+RUN /opt/keycloak/bin/kc.sh build 
+
+FROM quay.io/keycloak/keycloak:latest
+
+COPY --from=kcbuild /opt/keycloak/ /opt/keycloak/
+

--- a/demo/dest-app/index.html
+++ b/demo/dest-app/index.html
@@ -22,7 +22,7 @@
 <body onload="initKeycloak()">
   <h1>Showing "hidden" contents only after successful login</h1>
   <a
-    href="http://localhost:5080/auth/realms/master/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2Flocalhost%3A5081">Logout
+    href="http://localhost:5080/realms/master/protocol/openid-connect/logout?redirect_uri=http%3A%2F%2Flocalhost%3A5081">Logout
   </a>
 </body>
 

--- a/demo/start-app/index.html
+++ b/demo/start-app/index.html
@@ -11,10 +11,10 @@
       var providerUrl = "http://localhost:5080";
       var realm = "master";
       var targetClientForNewSession = "dest-app";
-      var jwt = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIwZnNNQ2F3Slg1SmhDcFpQMFl3TnlMYkt2T0EtNC00Z21od1h6aGNQcF84In0.eyJleHAiOjE2NDUwOTQwMDcsImlhdCI6MTY0NTA5Mzk0NywianRpIjoiNTYwMjRhYzQtMTdjZC00MjQwLWE3YzEtNWZhZDM2YmZjYWY1IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsImF1ZCI6ImFjY291bnQiLCJzdWIiOiIyODc3N2RkZi1iYzFjLTQxYTYtOTA4Yy1jMzFiNGM5NDZmZjAiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJwcml2YXRlIiwic2Vzc2lvbl9zdGF0ZSI6ImI1YjM3MzQyLWEyNDItNDQ3NC1iODcxLWEzNGU5OWI1ZThiOSIsImFjciI6IjEiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsiZGVmYXVsdC1yb2xlcy1tYXN0ZXIiLCJvZmZsaW5lX2FjY2VzcyIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3VudCI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiJwcm9maWxlIGVtYWlsIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0dXNlciJ9.l7TdoH8HfazBsVwvhEqBH-0yvdDVr5xc364A2DT41utonzpq2p2MdViY_GYRPs3tPIvDXqPs4AFjXRftKN4hg5t-8ZH5ndpOqYsVmXOm9xDQD4ypLTnfZdJ0wjEpkjK0_AUUU82o3wevUThreyGymnHESSeryG5YinnldbS5WNagRutoML7F1rC6gfWu6CL2Rkwhhm3rfK5OAv4ULBqBLzKU62YT7rUAtTj7FQYPwJi0WCxvYiio2hGwRPwkvciEskTC9U4bmFtxlcLdvFhgCxhf4qXz1GlR8VMYAi_WHWoJ1T_DayvDLcc3GrbExhrZzOihfxOncQdzRQWmjV-SlQ";
+      var jwt = "<REPLACE-TOKEN>";
       // invocation
       var xmlHttp = new XMLHttpRequest();
-      xmlHttp.open("GET", `${providerUrl}/auth/realms/${realm}/browser-session/init?publicClient=${targetClientForNewSession}`, false);
+      xmlHttp.open("POST", `${providerUrl}/realms/${realm}/browser-session/init?publicClient=${targetClientForNewSession}`, false);
       xmlHttp.withCredentials = true;
       xmlHttp.setRequestHeader("Authorization", "Bearer " + jwt);
       xmlHttp.send(null);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,28 @@
-version: '2'
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:11
+    image: postgres:17.2-alpine
     environment:
-      # ALLOW_EMPTY_PASSWORD is recommended only for development.
-      - ALLOW_EMPTY_PASSWORD=yes
-      - POSTGRESQL_USERNAME=bn_keycloak
-      - POSTGRESQL_DATABASE=bitnami_keycloak
+      POSTGRES_DB: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: password
     volumes:
-      - 'postgresql_data:/bitnami/postgresql'
+      - 'postgresql_data:/var/lib/postgresql/data/'
 
   keycloak:
-    image: docker.io/bitnami/keycloak:14
+    build:
+      dockerfile: ./build/Dockerfile
     depends_on:
       - postgresql
     ports:
       - "5080:8080"
+    environment:
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgresql/keycloak
+      KC_DB_USERNAME: keycloak
+      KC_DB_PASSWORD: password
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    command: "start-dev"
 
   dest-app:
     image: nginx

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.contabo.keycloak.spi.realmresourceprovider.browseresssion</groupId>
   <artifactId>keycloak-spi-browser-session-api</artifactId>
-  <version>1.0</version>
+  <version>1.1</version>
   <build>
     <plugins>
       <plugin>
@@ -14,8 +14,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
     </plugins>
@@ -23,10 +23,9 @@
   <packaging>jar</packaging>
 
   <properties>
-    <keycloak.version>14.0.0</keycloak.version>
+    <keycloak.version>26.1.0</keycloak.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>1.8</java.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/com/contabo/keycloak/spi/realmresourceprovider/browseresssion/BrowserSessionRestProvider.java
+++ b/src/main/java/com/contabo/keycloak/spi/realmresourceprovider/browseresssion/BrowserSessionRestProvider.java
@@ -1,6 +1,5 @@
 package com.contabo.keycloak.spi.realmresourceprovider.browseresssion;
 
-import org.jboss.resteasy.annotations.cache.NoCache;
 import org.keycloak.authorization.util.Tokens;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.events.Errors;
@@ -18,15 +17,15 @@ import org.keycloak.utils.MediaType;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import javax.ws.rs.Encoded;
-import javax.ws.rs.GET;
-import javax.ws.rs.OPTIONS;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.OPTIONS;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 
 public class BrowserSessionRestProvider implements RealmResourceProvider {
 
@@ -46,7 +45,6 @@ public class BrowserSessionRestProvider implements RealmResourceProvider {
 
   @OPTIONS
   @Path("init")
-  @NoCache
   @Produces({ MediaType.TEXT_PLAIN_UTF_8 })
   @Encoded
   public Response checkCORS(@QueryParam("publicClient") String targetClient) {
@@ -62,14 +60,13 @@ public class BrowserSessionRestProvider implements RealmResourceProvider {
         .header("Access-Control-Allow-Headers",
             BSAPI_ACCESS_CONTROL_ALLOW_HEADERS)
         .header("Access-Control-Allow-Methods",
-            "GET, OPTIONS")
+            "POST, OPTIONS")
         .entity("")
         .build();
   }
 
-  @GET
+  @POST
   @Path("init")
-  @NoCache
   @Produces({ MediaType.APPLICATION_JSON })
   @Encoded
   public Response setSessionCookies(@QueryParam("publicClient") String targetClient) {
@@ -79,7 +76,7 @@ public class BrowserSessionRestProvider implements RealmResourceProvider {
     final RealmModel realm = this.keycloakSession.getContext().getRealm();
 
     // create new user session and bind it to the target client Id
-    final UserModel user = this.keycloakSession.users().getUserById(validToken.getSubject(), realm);
+    final UserModel user = this.keycloakSession.users().getUserByEmail(realm, validToken.getEmail());
     final ClientConnection clientConnection = this.keycloakSession.getContext().getConnection();
     UserSessionModel newUserSession = this.keycloakSession.sessions().createUserSession(realm, user, user.getUsername(),
         clientConnection.getRemoteAddr(), "KEYCLOAK", false, null, null);


### PR DESCRIPTION
# Changes
1. Upgraded configuration source and target to 17 and keycloak version to 26.1.0
2. Modified imports since keycloak moved to jakarta
3. Removed no cache and set the method to POST so that it wont cache automatically
4. Modified compose file to use latest and official keycloak image as of now (26.1.0)
5. Modified compose file to use latest postgres image as of now (17.2)
6. Modified dest-app and start-app urls to match latest keycloak url pattern